### PR TITLE
Rz has no gradient issue resolved

### DIFF
--- a/tlquantum/tt_gates.py
+++ b/tlquantum/tt_gates.py
@@ -280,6 +280,7 @@ class RotZ(Module):
     def __init__(self, dtype=complex64, device=None):
         super().__init__()
         self.theta, self.dtype, self.device = Parameter(randn(1, device=device)), dtype, device
+        self.iden, self.epz = identity(dtype=dtype, device=self.theta.device), exp_pauli_z(dtype=dtype, device=self.theta.device)
 
 
     def forward(self):
@@ -291,7 +292,7 @@ class RotZ(Module):
         -------
         Gate tensor for general forward pass.
         """
-        return tl.tensor([[[[exp(-1j*self.theta/2)],[0]],[[0],[exp(1j*self.theta/2)]]]], dtype=self.dtype, device=self.device)
+        return self.iden*cos(self.theta/2)+self.epz*sin(self.theta/2)
 
 
 class IDENTITY(Module):
@@ -710,3 +711,14 @@ def exp_pauli_x(dtype=complex64, device=None):
     tt-tensor core, sin(theta) X-rotation component.
     """
     return tl.tensor([[[[0],[-1j]],[[-1j],[0]]]], dtype=dtype, device=device)
+
+def exp_pauli_z(dtype=complex64, device=None):
+    """Matrix for sin(theta) component of X-axis rotation in tt-tensor form.
+    Parameters
+    ----------
+    device : string, device on which to run the computation.
+    Returns
+    -------
+    tt-tensor core, sin(theta) X-rotation component.
+    """
+    return tl.tensor([[[[1],[0.]],[[0],[-1]]]], dtype=dtype, device=device)

--- a/tlquantum/tt_gates.py
+++ b/tlquantum/tt_gates.py
@@ -721,4 +721,4 @@ def exp_pauli_z(dtype=complex64, device=None):
     -------
     tt-tensor core, sin(theta) X-rotation component.
     """
-    return tl.tensor([[[[1],[0.]],[[0],[-1]]]], dtype=dtype, device=device)
+    return tl.tensor([[[[-1j],[0.]],[[0],[1j]]]], dtype=dtype, device=device)

--- a/tlquantum/tt_gates.py
+++ b/tlquantum/tt_gates.py
@@ -280,7 +280,6 @@ class RotZ(Module):
     def __init__(self, dtype=complex64, device=None):
         super().__init__()
         self.theta, self.dtype, self.device = Parameter(randn(1, device=device)), dtype, device
-        self.iden, self.epz = identity(dtype=dtype, device=self.theta.device), exp_pauli_z(dtype=dtype, device=self.theta.device)
 
 
     def forward(self):
@@ -292,7 +291,7 @@ class RotZ(Module):
         -------
         Gate tensor for general forward pass.
         """
-        return self.iden*cos(self.theta/2)+self.epz*sin(self.theta/2)
+        return tl.tensor([[[[exp(-1j*self.theta/2)],[0]],[[0],[exp(1j*self.theta/2)]]]], dtype=self.dtype, device=self.device)
 
 
 class IDENTITY(Module):
@@ -711,14 +710,3 @@ def exp_pauli_x(dtype=complex64, device=None):
     tt-tensor core, sin(theta) X-rotation component.
     """
     return tl.tensor([[[[0],[-1j]],[[-1j],[0]]]], dtype=dtype, device=device)
-
-def exp_pauli_z(dtype=complex64, device=None):
-    """Matrix for sin(theta) component of X-axis rotation in tt-tensor form.
-    Parameters
-    ----------
-    device : string, device on which to run the computation.
-    Returns
-    -------
-    tt-tensor core, sin(theta) X-rotation component.
-    """
-    return tl.tensor([[[[1],[0.]],[[0],[-1]]]], dtype=dtype, device=device)

--- a/tlquantum/tt_gates.py
+++ b/tlquantum/tt_gates.py
@@ -280,6 +280,7 @@ class RotZ(Module):
     def __init__(self, dtype=complex64, device=None):
         super().__init__()
         self.theta, self.dtype, self.device = Parameter(randn(1, device=device)), dtype, device
+        self.iden, self.epz = identity(dtype=dtype, device=self.theta.device), exp_pauli_z(dtype=dtype, device=self.theta.device)
 
 
     def forward(self):
@@ -291,7 +292,7 @@ class RotZ(Module):
         -------
         Gate tensor for general forward pass.
         """
-        return tl.tensor([[[[exp(-1j*self.theta/2)],[0]],[[0],[exp(1j*self.theta/2)]]]], dtype=self.dtype, device=self.device)
+        return self.iden*cos(self.theta/2)+self.epz*sin(self.theta/2)
 
 
 class IDENTITY(Module):
@@ -710,3 +711,14 @@ def exp_pauli_x(dtype=complex64, device=None):
     tt-tensor core, sin(theta) X-rotation component.
     """
     return tl.tensor([[[[0],[-1j]],[[-1j],[0]]]], dtype=dtype, device=device)
+
+def exp_pauli_z(dtype=complex64, device=None):
+    """Matrix for sin(theta) component of Z-axis rotation in tt-tensor form.
+    Parameters
+    ----------
+    device : string, device on which to run the computation.
+    Returns
+    -------
+    tt-tensor core, sin(theta) X-rotation component.
+    """
+    return tl.tensor([[[[1],[0.]],[[0],[-1]]]], dtype=dtype, device=device)


### PR DESCRIPTION
Hey there, 
The way RotZ was implemented it didn't have any gradient. I fixed the issue by using the same template as for the RotY and RotX. I think the tl.tensor() in the original version somehow blocked the backprop. The way it is written now the gradient is correct.